### PR TITLE
Lock release

### DIFF
--- a/contracts/contracts/Checkpoints.sol
+++ b/contracts/contracts/Checkpoints.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts-4/utils/math/Math.sol";
+import "@openzeppelin/contracts-4/utils/math/SafeCast.sol";
+
+interface Escrow {
+    // function getBalance(address _token, address _address, uint _block) external view returns (uint);
+}
+
+contract Checkpoints is Escrow {
+    struct Checkpoint {
+        uint32 fromBlock;
+        uint224 votes;
+    }
+
+    mapping(address => mapping(address => Checkpoint[])) private _checkpoints;
+    mapping(address => Checkpoint[]) private _totalSupplyCheckpoints;
+
+    /**
+     * @dev Clock used for flagging checkpoints. Can be overridden to implement timestamp based checkpoints (and voting).
+     */
+    function clock() public view virtual returns (uint48) {
+        return SafeCast.toUint48(block.number);
+    }
+
+    /**
+     * @dev Get the `pos`-th checkpoint for `account`.
+     */
+    function checkpoints(address token, address account, uint32 pos) public view virtual returns (Checkpoint memory) {
+        return _checkpoints[token][account][pos];
+    }
+
+    
+    /**
+     * @dev Get number of checkpoints for `account`.
+     */
+    function numCheckpoints(address token, address account) public view virtual returns (uint32) {
+        return SafeCast.toUint32(_checkpoints[token][account].length);
+    }
+
+    /**
+     * @dev Gets the current votes balance for `account`
+     */
+    function getVotes(address token, address account) public view virtual returns (uint256) {
+        uint256 pos = _checkpoints[token][account].length;
+        unchecked {
+            return pos == 0 ? 0 : _checkpoints[token][account][pos - 1].votes;
+        }
+    }
+
+    /**
+     * @dev Retrieve the number of votes for `account` at the end of `timepoint`.
+     *
+     * Requirements:
+     *
+     * - `timepoint` must be in the past
+     */
+    function getPastVotes(address token, address account, uint256 timepoint) public view virtual returns (uint256) {
+        require(timepoint < clock(), "ERC20Votes: future lookup");
+        return _checkpointsLookup(_checkpoints[token][account], timepoint);
+    }
+
+    /**
+     * @dev Retrieve the `totalSupply` at the end of `timepoint`. Note, this value is the sum of all balances.
+     * It is NOT the sum of all the delegated votes!
+     *
+     * Requirements:
+     *
+     * - `timepoint` must be in the past
+     */
+    function getPastTotalSupply(address token, uint256 timepoint) public view virtual returns (uint256) {
+        require(timepoint < clock(), "ERC20Votes: future lookup");
+        return _checkpointsLookup(_totalSupplyCheckpoints[token], timepoint);
+    }
+
+    /**
+     * @dev Lookup a value in a list of (sorted) checkpoints.
+     */
+    function _checkpointsLookup(Checkpoint[] storage ckpts, uint256 timepoint) private view returns (uint256) {
+        // We run a binary search to look for the last (most recent) checkpoint taken before (or at) `timepoint`.
+        //
+        // Initially we check if the block is recent to narrow the search range.
+        // During the loop, the index of the wanted checkpoint remains in the range [low-1, high).
+        // With each iteration, either `low` or `high` is moved towards the middle of the range to maintain the invariant.
+        // - If the middle checkpoint is after `timepoint`, we look in [low, mid)
+        // - If the middle checkpoint is before or equal to `timepoint`, we look in [mid+1, high)
+        // Once we reach a single value (when low == high), we've found the right checkpoint at the index high-1, if not
+        // out of bounds (in which case we're looking too far in the past and the result is 0).
+        // Note that if the latest checkpoint available is exactly for `timepoint`, we end up with an index that is
+        // past the end of the array, so we technically don't find a checkpoint after `timepoint`, but it works out
+        // the same.
+        uint256 length = ckpts.length;
+
+        uint256 low = 0;
+        uint256 high = length;
+
+        if (length > 5) {
+            uint256 mid = length - Math.sqrt(length);
+            if (_unsafeAccess(ckpts, mid).fromBlock > timepoint) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        while (low < high) {
+            uint256 mid = Math.average(low, high);
+            if (_unsafeAccess(ckpts, mid).fromBlock > timepoint) {
+                high = mid;
+            } else {
+                low = mid + 1;
+            }
+        }
+
+        unchecked {
+            return high == 0 ? 0 : _unsafeAccess(ckpts, high - 1).votes;
+        }
+    }
+
+    /**
+     * @dev Maximum token supply. Defaults to `type(uint224).max` (2^224^ - 1).
+     */
+    function _maxSupply() internal view virtual returns (uint224) {
+        return type(uint224).max;
+    }
+
+    /**
+     * @dev Snapshots the totalSupply after it has been increased.
+     */
+    function _mint(address token, uint256 amount) internal virtual {
+        _writeCheckpoint(_totalSupplyCheckpoints[token], _add, amount);
+    }
+
+    /**
+     * @dev Snapshots the totalSupply after it has been decreased.
+     */
+    function _burn(address token, uint256 amount) internal virtual {
+        _writeCheckpoint(_totalSupplyCheckpoints[token], _subtract, amount);
+    }
+
+    /**
+     * @dev Move voting power when tokens are transferred.
+     *
+     * Emits a {IVotes-DelegateVotesChanged} event.
+     */
+    function _afterTokenTransfer(address token, address from, address to, uint256 amount) internal virtual {
+        if (from != to && amount > 0) {
+            if (from != address(0)) {
+                _writeCheckpoint(_checkpoints[token][from], _subtract, amount);
+            }
+
+            if (to != address(0)) {
+                _writeCheckpoint(_checkpoints[token][to], _add, amount);
+            }
+        }
+    }
+
+    function _writeCheckpoint(
+        Checkpoint[] storage ckpts,
+        function(uint256, uint256) view returns (uint256) op,
+        uint256 delta
+    ) private returns (uint256 oldWeight, uint256 newWeight) {
+        uint256 pos = ckpts.length;
+
+        unchecked {
+            Checkpoint memory oldCkpt = pos == 0 ? Checkpoint(0, 0) : _unsafeAccess(ckpts, pos - 1);
+
+            oldWeight = oldCkpt.votes;
+            newWeight = op(oldWeight, delta);
+
+            if (pos > 0 && oldCkpt.fromBlock == clock()) {
+                _unsafeAccess(ckpts, pos - 1).votes = SafeCast.toUint224(newWeight);
+            } else {
+                ckpts.push(Checkpoint({fromBlock: SafeCast.toUint32(clock()), votes: SafeCast.toUint224(newWeight)}));
+            }
+        }
+    }
+
+    function _add(uint256 a, uint256 b) private pure returns (uint256) {
+        return a + b;
+    }
+
+    function _subtract(uint256 a, uint256 b) private pure returns (uint256) {
+        return a - b;
+    }
+
+    /**
+     * @dev Access an element of the array without performing bounds check. The position is assumed to be within bounds.
+     */
+    function _unsafeAccess(Checkpoint[] storage ckpts, uint256 pos) private pure returns (Checkpoint storage result) {
+        assembly {
+            mstore(0, ckpts.slot)
+            result.slot := add(keccak256(0, 0x20), pos)
+        }
+    }
+}

--- a/contracts/contracts/GeneralTokenVesting.sol
+++ b/contracts/contracts/GeneralTokenVesting.sol
@@ -2,8 +2,8 @@
 
 pragma solidity ^0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts-3/token/ERC20/SafeERC20.sol";
+import "@openzeppelin/contracts-3/math/SafeMath.sol";
 
 /**
  * @title GeneralTokenVesting

--- a/contracts/contracts/LockRelease.sol
+++ b/contracts/contracts/LockRelease.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts-4/token/ERC20/utils/SafeERC20.sol";
+
+/// @title LockRelease
+/// @dev This contract allows to create token release schedules and to release those tokens.
+contract LockRelease {
+    using SafeERC20 for IERC20;
+
+    /// @dev Represents a release schedule for a specific beneficiary.
+    struct Schedule {
+        uint256 total; // total tokens that the beneficiary will receive over the duration
+        uint256 released; // already released tokens to the beneficiary
+        uint128 start; // start timestamp of the release schedule
+        uint128 duration; // duration of the release schedule in seconds
+    }
+
+    /// @dev Mapping of token address => beneficiary address => release schedule.
+    mapping(address => mapping(address => Schedule)) private _schedules;
+
+    /// @dev Emitted when a release schedule is created.
+    event ScheduleStarted(
+        address indexed token,
+        address indexed beneficiary,
+        address indexed creator
+    );
+
+    /// @dev Emitted when tokens are released to a recipient.
+    event TokensReleased(
+        address indexed token,
+        address indexed beneficiary,
+        address recipient,
+        uint256 amount,
+        address indexed releasor
+    );
+
+    /// @notice Returns the total tokens that will be released to the beneficiary over the duration.
+    function getTotal(address token, address beneficiary)
+        public
+        view
+        returns (uint256)
+    {
+        return _schedules[token][beneficiary].total;
+    }
+
+    /// @notice Returns the total tokens already released to the beneficiary.
+    function getReleased(address token, address beneficiary)
+        public
+        view
+        returns (uint256)
+    {
+        return _schedules[token][beneficiary].released;
+    }
+
+    /// @notice Returns the start timestamp of the beneficiary's release schedule.
+    function getStart(address token, address beneficiary)
+        public
+        view
+        returns (uint256)
+    {
+        return _schedules[token][beneficiary].start;
+    }
+
+    /// @notice Returns the duration of the beneficiary's release schedule.
+    function getDuration(address token, address beneficiary)
+        public
+        view
+        returns (uint256)
+    {
+        return _schedules[token][beneficiary].duration;
+    }
+
+    /// @notice Returns the total tokens that have matured until now according to the release schedule.
+    function getTotalMatured(address token, address beneficiary)
+        public
+        view
+        returns (uint256)
+    {
+        Schedule memory schedule = _schedules[token][beneficiary];
+
+        if (block.timestamp < schedule.start) {
+            return 0;
+        }
+
+        if (block.timestamp >= schedule.start + schedule.duration) {
+            return schedule.total;
+        }
+
+        return
+            (schedule.total * (block.timestamp - schedule.start)) /
+            schedule.duration;
+    }
+
+    /// @notice Returns the total tokens that can be released now.
+    function getReleasable(address token, address beneficiary)
+        public
+        view
+        returns (uint256)
+    {
+        return
+            getTotalMatured(token, beneficiary) -
+            getReleased(token, beneficiary);
+    }
+
+    /// @notice Creates a release schedule for the given beneficiary.
+    function createSchedule(
+        address token,
+        address beneficiary,
+        uint256 total,
+        uint128 start,
+        uint128 duration
+    ) public {
+        // Validations
+        require(duration > 0, "LockRelease: duration is 0");
+        require(
+            beneficiary != address(0),
+            "LockRelease: beneficiary is the zero address"
+        );
+        require(
+            address(token) != address(0),
+            "LockRelease: token is the zero address"
+        );
+        require(total != 0, "LockRelease: total is zero");
+        require(
+            _schedules[token][beneficiary].total == 0,
+            "LockRelease: Schedule already created for this token => beneficiary"
+        );
+
+        // Transfer tokens from sender to contract
+        uint256 before = IERC20(token).balanceOf(address(this));
+        IERC20(token).safeTransferFrom(msg.sender, address(this), total);
+        uint256 afterr = IERC20(token).balanceOf(address(this));
+        uint256 result = afterr - before;
+        require(result != 0, "LockRelease: amount is zero");
+
+        // Save release schedule
+        Schedule memory schedule = Schedule(result, 0, start, duration);
+        _schedules[token][beneficiary] = schedule;
+
+        emit ScheduleStarted(token, beneficiary, msg.sender);
+    }
+
+    /// @dev Internal function to release tokens according to the release schedule.
+    function _release(
+        address token,
+        address beneficiary,
+        address recipient,
+        uint256 amount
+    ) private {
+        // Validations
+        uint256 unreleased = getReleasable(token, beneficiary);
+        require(unreleased > 0, "LockRelease: no tokens are due");
+        require(amount > 0, "LockRelease: can't claim 0 tokens");
+        require(
+            amount <= unreleased,
+            "LockRelease: too many tokens being claimed"
+        );
+
+        // Update released amount
+        _schedules[token][beneficiary].released =
+            _schedules[token][beneficiary].released +
+            amount;
+
+        // Transfer tokens to recipient
+        IERC20(token).safeTransfer(recipient, amount);
+        emit TokensReleased(token, beneficiary, recipient, amount, msg.sender);
+    }
+
+    /// @notice Release tokens to beneficiary.
+    function release(
+        address token,
+        address beneficiary,
+        uint256 amount
+    ) public {
+        _release(token, beneficiary, beneficiary, amount);
+    }
+
+    /// @notice Release all releasable tokens to beneficiary.
+    function release(address token, address beneficiary) public {
+        release(token, beneficiary, getReleasable(token, beneficiary));
+    }
+
+    /// @notice Release tokens to a different recipient.
+    function releaseTo(
+        address token,
+        address recipient,
+        uint256 amount
+    ) public {
+        _release(token, msg.sender, recipient, amount);
+    }
+
+    /// @notice Release all releasable tokens to a different recipient.
+    function releaseTo(address token, address recipient) public {
+        releaseTo(token, recipient, getReleasable(token, msg.sender));
+    }
+}

--- a/contracts/contracts/LockRelease.sol
+++ b/contracts/contracts/LockRelease.sol
@@ -2,11 +2,12 @@
 
 pragma solidity ^0.8.19;
 
+import "./Checkpoints.sol";
 import "@openzeppelin/contracts-4/token/ERC20/utils/SafeERC20.sol";
 
 /// @title LockRelease
 /// @dev This contract allows to create token release schedules and to release those tokens.
-contract LockRelease {
+contract LockRelease is Checkpoints {
     using SafeERC20 for IERC20;
 
     /// @dev Represents a release schedule for a specific beneficiary.

--- a/contracts/contracts/mocks/IERC20Metadata.sol
+++ b/contracts/contracts/mocks/IERC20Metadata.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts-3/token/ERC20/IERC20.sol";
 
 /**
  * @dev Interface for the optional metadata functions from the ERC20 standard.

--- a/contracts/contracts/mocks/Mintable.sol
+++ b/contracts/contracts/mocks/Mintable.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.6.12;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts-3/token/ERC20/ERC20.sol";
 
 contract Mintable is ERC20 {
     constructor() ERC20("Mintable", "MINT") public {}

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -7,13 +7,26 @@ dotenv.config({ path: "../.env.local" });
 
 const config: HardhatUserConfig = {
   solidity: {
-    version: "0.6.12",
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: "0.6.12",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: "0.8.19",
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      }
+    ]
   },
   networks: {
     hardhat: {

--- a/contracts/test/LockRelease.test.ts
+++ b/contracts/test/LockRelease.test.ts
@@ -1,0 +1,452 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import {
+  LockRelease, LockRelease__factory,
+  Mintable, Mintable__factory
+} from '../typechain';
+import time from './time';
+
+describe('LockRelease', () => {
+  let owner: SignerWithAddress,
+    beneficiary1: SignerWithAddress,
+    beneficiary2: SignerWithAddress,
+    beneficiary3: SignerWithAddress,
+    recipient: SignerWithAddress;
+
+  let lockRelease: LockRelease,
+    token1: Mintable,
+    token2: Mintable,
+    token3: Mintable;
+
+  const duration1 = time.duration.years(1);
+  const duration2 = time.duration.years(2);
+  const duration3 = time.duration.years(3);
+
+  const amount = BigNumber.from('1000');
+  const mintAmount = BigNumber.from('20000');
+
+  beforeEach(async function () {
+    [owner, beneficiary1, beneficiary2, beneficiary3, recipient] = await ethers.getSigners();
+
+    lockRelease = await new LockRelease__factory(owner).deploy();
+    token1 = await new Mintable__factory(owner).deploy();
+    token2 = await new Mintable__factory(owner).deploy();
+    token3 = await new Mintable__factory(owner).deploy();
+
+    await token1.mint(owner.address, mintAmount);
+    await token2.mint(owner.address, mintAmount);
+    await token3.mint(owner.address, mintAmount);
+
+    await token1.approve(lockRelease.address, mintAmount);
+    await token2.approve(lockRelease.address, mintAmount);
+    await token3.approve(lockRelease.address, mintAmount);
+  });
+
+  it('reverts with a zero beneficiary', async function () {
+    await expect(
+      lockRelease.createSchedule(token1.address, ethers.constants.AddressZero, amount, 0, duration1)
+    ).to.be.revertedWith("LockRelease: beneficiary is the zero address");
+  });
+
+  it('reverts with a zero token', async function () {
+    await expect(
+      lockRelease.createSchedule(ethers.constants.AddressZero, beneficiary1.address, amount, 0, duration1)
+    ).to.be.revertedWith("LockRelease: token is the zero address");
+  });
+
+  it('reverts with a zero total', async function () {
+    await expect(
+      lockRelease.createSchedule(token1.address, beneficiary1.address, 0, 0, duration1)
+    ).to.be.revertedWith("LockRelease: total is zero");
+  });
+
+  it('reverts with a null duration', async function () {
+    await expect(
+      lockRelease.createSchedule(token1.address, beneficiary1.address, amount, 0, 0)
+    ).to.be.revertedWith("LockRelease: duration is 0");
+  });
+
+  it('reverts with a duplicate schedule', async function () {
+    await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, 0, duration1);
+    await expect(
+      lockRelease.createSchedule(token1.address, beneficiary1.address, amount, 0, duration1)
+    ).to.be.revertedWith("LockRelease: Schedule already created for this token => beneficiary");
+  });
+
+  it('reverts with contract not approved to transfer tokens', async function () {
+    await token2.approve(lockRelease.address, 0);
+    await expect(
+      lockRelease.createSchedule(token2.address, beneficiary1.address, amount, 0, duration1)
+    ).to.be.revertedWith("ERC20: transfer amount exceeds allowance");
+  });
+
+  it('reverts with contract transferring more than approved', async function () {
+    await expect(
+      lockRelease.createSchedule(token1.address, beneficiary2.address, 30000, 0, duration1)
+    ).to.be.revertedWith("ERC20: transfer amount exceeds balance");
+  });
+
+  it('transfers tokens to contract address', async function () {
+    await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, 0, duration1);
+    expect(await token1.balanceOf(lockRelease.address)).to.equal(amount);
+  });
+
+  context('once schedule has started', function () {
+    let start: BigNumber,
+      durationSchedule: BigNumber;
+
+    beforeEach(async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      start = await lockRelease.getStart(token1.address, beneficiary1.address);
+      durationSchedule = await lockRelease.getDuration(token1.address, beneficiary1.address);
+    });
+
+    it('can get state', async function () {
+      expect(await lockRelease.getTotal(token1.address, beneficiary1.address)).to.equal(amount);
+    });
+
+    it('can be released', async function () {
+      await time.increaseTo(start.add(durationSchedule).toNumber());
+
+      await expect(lockRelease['release(address,address)'](token1.address, beneficiary1.address))
+        .to.emit(lockRelease, 'TokensReleased')
+        .withArgs(token1.address, beneficiary1.address, beneficiary1.address, amount, owner.address);
+    });
+
+    it('can be releasedTo', async function () {
+      await time.increaseTo(start.add(durationSchedule).toNumber());
+
+      await expect(lockRelease.connect(beneficiary1)['releaseTo(address,address)'](token1.address, recipient.address))
+        .to.emit(lockRelease, 'TokensReleased')
+        .withArgs(token1.address, beneficiary1.address, recipient.address, amount, beneficiary1.address);
+    });
+
+    it('release reverts with beneficiary scheduled time is < 0', async function () {
+      await expect(
+        lockRelease['release(address,address)'](token1.address, beneficiary1.address)
+      ).to.be.revertedWith("LockRelease: no tokens are due");
+    });
+
+    it('releaseTo reverts with beneficiary scheduled time is < 0', async function () {
+      await expect(
+        lockRelease.connect(beneficiary1)['releaseTo(address,address)'](token1.address, recipient.address)
+      ).to.be.revertedWith("LockRelease: no tokens are due");
+    });
+
+    it('release reverts with beneficiary does not exist', async function () {
+      await expect(
+        lockRelease['release(address,address)'](token1.address, beneficiary2.address)
+      ).to.be.revertedWith("LockRelease: no tokens are due");
+    });
+
+    it('releaseTo reverts with beneficiary does not exist', async function () {
+      await expect(
+        lockRelease.connect(beneficiary2)['releaseTo(address,address)'](token1.address, recipient.address)
+      ).to.be.revertedWith("LockRelease: no tokens are due");
+    });
+
+    it('release reverts with token does not exist', async function () {
+      await expect(
+        lockRelease['release(address,address)'](token2.address, beneficiary2.address)
+      ).to.be.revertedWith("LockRelease: no tokens are due");
+    });
+
+    it('releaseTo reverts with token does not exist', async function () {
+      await expect(
+        lockRelease.connect(beneficiary2)['release(address,address)'](token2.address, recipient.address)
+      ).to.be.revertedWith("LockRelease: no tokens are due");
+    });
+
+    it('should release proper amount', async function () {
+      await time.increaseTo(start.add(duration1).toNumber());
+
+      await lockRelease['release(address,address)'](token1.address, beneficiary1.address);
+      const releaseTime = await time.latest();
+
+      const releasedAmount = amount.mul(BigNumber.from(releaseTime).sub(start)).div(durationSchedule);
+      expect(await token1.balanceOf(beneficiary1.address)).to.equal(releasedAmount);
+      expect(await lockRelease.getReleased(token1.address, beneficiary1.address)).to.equal(releasedAmount);
+    });
+
+    it('release should linearly release tokens during maturing period', async function () {
+      const maturingPeriod = durationSchedule;
+      const checkpoints = 4;
+
+      for (let i = 1; i <= checkpoints; i++) {
+        const now = start.add((maturingPeriod.mul(i).div(checkpoints)));
+        await time.increaseTo(now.toNumber());
+
+        await lockRelease['release(address,address)'](token1.address, beneficiary1.address);
+        const expectedMaturing = amount.mul(now.sub(start)).div(durationSchedule);
+        expect(await token1.balanceOf(beneficiary1.address)).to.equal(expectedMaturing);
+        expect(await lockRelease.getReleased(token1.address, beneficiary1.address)).to.equal(expectedMaturing);
+      }
+    });
+
+    it('releaseTo should linearly release tokens during maturing period', async function () {
+      const maturingPeriod = durationSchedule;
+      const checkpoints = 4;
+
+      for (let i = 1; i <= checkpoints; i++) {
+        const now = start.add((maturingPeriod.mul(i).div(checkpoints)));
+        await time.increaseTo(now.toNumber());
+
+        await lockRelease.connect(beneficiary1)['releaseTo(address,address)'](token1.address, recipient.address);
+        const expectedMaturing = amount.mul(now.sub(start)).div(durationSchedule);
+        expect(await token1.balanceOf(recipient.address)).to.equal(expectedMaturing);
+        expect(await lockRelease.getReleased(token1.address, beneficiary1.address)).to.equal(expectedMaturing);
+      }
+    });
+
+    it('should have released all after end', async function () {
+      await time.increaseTo(start.add(durationSchedule).toNumber());
+      await lockRelease['release(address,address)'](token1.address, beneficiary1.address);
+      expect(await token1.balanceOf(beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getReleased(token1.address, beneficiary1.address)).to.equal(amount);
+    });
+  });
+
+  context('multiple beneficiary/durations/tokens', function () {
+    it('can get state (multiple beneficiaries)', async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      await lockRelease.createSchedule(token1.address, beneficiary2.address, amount, await time.latest(), duration1);
+      await lockRelease.createSchedule(token1.address, beneficiary3.address, amount, await time.latest(), duration1);
+
+      // beneficiary1
+      expect(await lockRelease.getTotal(token1.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary1.address)).to.equal(duration1);
+
+      // beneficiary2
+      expect(await lockRelease.getTotal(token1.address, beneficiary2.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary2.address)).to.equal(duration1);
+
+      // beneficiary3
+      expect(await lockRelease.getTotal(token1.address, beneficiary3.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary3.address)).to.equal(duration1);
+    });
+
+    it('can get state (multiple durations)', async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      await lockRelease.createSchedule(token1.address, beneficiary2.address, amount, await time.latest(), duration2);
+      await lockRelease.createSchedule(token1.address, beneficiary3.address, amount, await time.latest(), duration3);
+
+      // duration1
+      expect(await lockRelease.getTotal(token1.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary1.address)).to.equal(duration1);
+
+      // duration2
+      expect(await lockRelease.getTotal(token1.address, beneficiary2.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary2.address)).to.equal(duration2);
+
+      // duration3
+      expect(await lockRelease.getTotal(token1.address, beneficiary3.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary3.address)).to.equal(duration3);
+    });
+
+    it('can get state (multiple tokens)', async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      await lockRelease.createSchedule(token2.address, beneficiary1.address, amount, await time.latest(), duration1);
+      await lockRelease.createSchedule(token3.address, beneficiary1.address, amount, await time.latest(), duration1);
+
+      // token1
+      expect(await lockRelease.getTotal(token1.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary1.address)).to.equal(duration1);
+
+      // token2
+      expect(await lockRelease.getTotal(token2.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token2.address, beneficiary1.address)).to.equal(duration1);
+
+      // token3
+      expect(await lockRelease.getTotal(token3.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token3.address, beneficiary1.address)).to.equal(duration1);
+    });
+
+    it('can get state (start schedules at a different time)', async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      const start = await lockRelease.getStart(token1.address, beneficiary1.address);
+      await time.increaseTo(start.add(duration1).toNumber());
+      await lockRelease.createSchedule(token1.address, beneficiary2.address, amount, await time.latest(), duration1);
+
+      // schedule1
+      expect(await lockRelease.getTotal(token1.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary1.address)).to.equal(duration1);
+
+      // schedule2
+      expect(await lockRelease.getTotal(token1.address, beneficiary2.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token1.address, beneficiary2.address)).to.equal(duration1);
+    });
+
+    it('can get state(for an address that has released tokens and started a new schedule)', async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      const start = await lockRelease.getStart(token1.address, beneficiary1.address);
+      const durationSchedule = await lockRelease.getDuration(token1.address, beneficiary1.address);
+      await time.increaseTo(start.add(durationSchedule).toNumber());
+      await lockRelease['release(address,address)'](token1.address, beneficiary1.address);
+
+      // schedule with same beneficiary
+      await lockRelease.createSchedule(token2.address, beneficiary1.address, amount, await time.latest(), duration1);
+
+      // schedule1
+      expect(await token1.balanceOf(beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getReleased(token1.address, beneficiary1.address)).to.equal(amount);
+
+      // schedule2
+      expect(await lockRelease.getTotal(token2.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token2.address, beneficiary1.address)).to.equal(duration1);
+    });
+
+    it('can get state(for an address that has releasedTo tokens and started a new schedule)', async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      const start = await lockRelease.getStart(token1.address, beneficiary1.address);
+      const durationSchedule = await lockRelease.getDuration(token1.address, beneficiary1.address);
+      await time.increaseTo(start.add(durationSchedule).toNumber());
+      await lockRelease.connect(beneficiary1)['releaseTo(address,address)'](token1.address, recipient.address);
+
+      // schedule with same beneficiary
+      await lockRelease.createSchedule(token2.address, beneficiary1.address, amount, await time.latest(), duration1);
+
+      // schedule1
+      expect(await token1.balanceOf(recipient.address)).to.equal(amount);
+      expect(await lockRelease.getReleased(token1.address, beneficiary1.address)).to.equal(amount);
+
+      // schedule2
+      expect(await lockRelease.getTotal(token2.address, beneficiary1.address)).to.equal(amount);
+      expect(await lockRelease.getDuration(token2.address, beneficiary1.address)).to.equal(duration1);
+    });
+  });
+
+  context("creating a schedule with start date in past", function () {
+    let startDateInThePast: number;
+
+    beforeEach(async function () {
+      startDateInThePast = await time.latest() - duration1 / 2;
+    });
+
+    context("the current time is in the middle of the schedule", function () {
+      beforeEach(async function () {
+        await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, startDateInThePast, duration1);
+      });
+
+      it("calculates the correct amount of tokens that have been matured", async function () {
+        const matured = await lockRelease.getTotalMatured(token1.address, beneficiary1.address);
+        expect(matured).to.equal(amount.div(2));
+      });
+
+      it("calculates the correct amount of tokens to be released", async function () {
+        const releasable = await lockRelease.getReleasable(token1.address, beneficiary1.address);
+        expect(releasable).to.equal(amount.div(2));
+      });
+    });
+
+    context("the current time is after the schedule has ended", function () {
+      beforeEach(async function () {
+        await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, startDateInThePast, duration1);
+        await time.increase(duration1 * 2);
+      });
+
+      it("calculates that all tokens have matured", async function () {
+        const matured = await lockRelease.getTotalMatured(token1.address, beneficiary1.address);
+        expect(matured).to.equal(amount);
+      });
+
+      it("calculates that all tokens can be released", async function () {
+        const releasable = await lockRelease.getReleasable(token1.address, beneficiary1.address);
+        expect(releasable).to.equal(amount);
+      });
+    });
+  });
+
+  context("creating a schedule with start date in future", function () {
+    let startDateInTheFuture: number;
+
+    beforeEach(async function () {
+      startDateInTheFuture = await time.latest() + duration1;
+    });
+
+    beforeEach(async function () {
+      await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, startDateInTheFuture, duration1);
+    });
+
+    it("says no tokens are matured", async function () {
+      const matured = await lockRelease.getTotalMatured(token1.address, beneficiary1.address);
+      expect(matured).to.equal(0);
+    });
+
+    it("says no tokens are releasable", async function () {
+      const releasable = await lockRelease.getReleasable(token1.address, beneficiary1.address);
+      expect(releasable).to.equal(0);
+    });
+
+    context("checking info after maturing starts", function () {
+      beforeEach(async function () {
+        await time.increase(duration1 * 2);
+      });
+
+      it("says some tokens are matured", async function () {
+        const matured = await lockRelease.getTotalMatured(token1.address, beneficiary1.address);
+        expect(matured).to.be.above(0);
+      });
+
+      it("says some tokens are releasable", async function () {
+        const releasable = await lockRelease.getReleasable(token1.address, beneficiary1.address);
+        expect(releasable).to.be.above(0);
+      });
+    });
+  });
+
+  context("releasing a specific number of tokens", function () {
+    context("claiming more tokens than are due", function () {
+      beforeEach(async function () {
+        await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      });
+
+      it("should fail", async function () {
+        await time.increase(duration1 / 2);
+        await expect(
+          lockRelease['release(address,address,uint256)'](token1.address, beneficiary1.address, amount)
+        ).to.be.revertedWith("LockRelease: too many tokens being claimed");
+      });
+    });
+
+    context("claiming less than the amount of tokens that are due", function () {
+      beforeEach(async function () {
+        await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      });
+
+      it("should release the requested amount", async function () {
+        await time.increase(duration1);
+        await lockRelease['release(address,address,uint256)'](token1.address, beneficiary1.address, amount.div(2));
+        expect(await token1.balanceOf(beneficiary1.address)).to.equal(amount.div(2));
+      });
+    });
+  });
+
+  context("releasing to a specific number of tokens", function () {
+    context("claiming more tokens than are due", function () {
+      beforeEach(async function () {
+        await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      });
+
+      it("should fail", async function () {
+        await time.increase(duration1 / 2);
+        await expect(
+          lockRelease.connect(beneficiary1)['releaseTo(address,address,uint256)'](token1.address, beneficiary2.address, amount)
+        ).to.be.revertedWith("LockRelease: too many tokens being claimed");
+      });
+    });
+
+    context("claiming less than the amount of tokens that are due", function () {
+      beforeEach(async function () {
+        await lockRelease.createSchedule(token1.address, beneficiary1.address, amount, await time.latest(), duration1);
+      });
+
+      it("should release the requested amount to the specific address", async function () {
+        await time.increase(duration1)
+        await lockRelease.connect(beneficiary1)['releaseTo(address,address,uint256)'](token1.address, beneficiary2.address, amount.div(2));
+        expect(await token1.balanceOf(beneficiary2.address)).to.equal(amount.div(2));
+      });
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
-        "@openzeppelin/contracts": "^3.3.0",
+        "@openzeppelin/contracts-3": "npm:@openzeppelin/contracts@^3.3.0",
         "@typechain/ethers-v5": "^7.1.2",
         "@typechain/hardhat": "^2.3.0",
         "@types/chai": "^4.2.22",
@@ -6547,7 +6547,8 @@
         "node": ">=10"
       }
     },
-    "node_modules/@openzeppelin/contracts": {
+    "node_modules/@openzeppelin/contracts-3": {
+      "name": "@openzeppelin/contracts",
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@nomiclabs/hardhat-ethers": "^2.0.2",
         "@nomiclabs/hardhat-waffle": "^2.0.1",
         "@openzeppelin/contracts-3": "npm:@openzeppelin/contracts@^3.3.0",
+        "@openzeppelin/contracts-4": "npm:@openzeppelin/contracts@^4.9.0",
         "@typechain/ethers-v5": "^7.1.2",
         "@typechain/hardhat": "^2.3.0",
         "@types/chai": "^4.2.22",
@@ -6552,6 +6553,13 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.4.2.tgz",
       "integrity": "sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==",
+      "dev": true
+    },
+    "node_modules/@openzeppelin/contracts-4": {
+      "name": "@openzeppelin/contracts",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.9.0.tgz",
+      "integrity": "sha512-DUP74AFGKlic2sQb/CmgrN2aUPMFGxRrmCTUxLHsiU2RzwWqVuMPZBxiAyvlff6Pea77uylAX6B5x9W6evEbhA==",
       "dev": true
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts-3": "npm:@openzeppelin/contracts@^3.3.0",
+    "@openzeppelin/contracts-4": "npm:@openzeppelin/contracts@^4.9.0",
     "@typechain/ethers-v5": "^7.1.2",
     "@typechain/hardhat": "^2.3.0",
     "@types/chai": "^4.2.22",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
-    "@openzeppelin/contracts": "^3.3.0",
+    "@openzeppelin/contracts-3": "npm:@openzeppelin/contracts@^3.3.0",
     "@typechain/ethers-v5": "^7.1.2",
     "@typechain/hardhat": "^2.3.0",
     "@types/chai": "^4.2.22",


### PR DESCRIPTION
This PR introduces a simple contract called `LockRelease` that allows locking / linear-releasing schedules to be created by anyone with arbitrary tokens for arbitrary beneficiaries in arbitrary timeframes.

This codebase is already reasonably mature, and also includes a frontend that will need to be updated later, as well as the "first version" of this contract called `GeneralTokenVesting` which is less featureful.

The expectation is that `LockRelease` can be used for DCNT's token launch, which has a requirement of locking DCNT tokens for recipients for 1 year and then releasing those tokens (to be claimed) on a linear per-second slope over the next 2 years. The frontend can also be updated to support this new contract.

See the `GeneralTokenVesting` contract and the current frontend which supports it at https://vesting.decentlabs.io

To get the tests running:

* `nvm use`
* `npm install`
* `cp .env .env.local`
* fill in an archive node RPC into the MAINNET_PROVIDER env var
* `npm run contracts:compile`
* `npm run contracts:test`

Contract features include:
* starting the linear release in the past, if for some reason you want to do that
* starting the linear release in the future, all tokens for that schedule being locked until then
* releasing all matured tokens, or just a subset of them
* anyone being able to release tokens on behalf of a beneficiary to that beneficiary
* a beneficiary being able to release their tokens to an arbitrary address at the time of release